### PR TITLE
Rg/37384 split output in two

### DIFF
--- a/lib/openapi3.js
+++ b/lib/openapi3.js
@@ -693,23 +693,36 @@ function convertInner(api, options, callback) {
         return s.split('\r').join('').split('\n').join(' ').trim();
     };
 
+    let content = options.splitOutPath ? createSplitContent(templates, header, data, options, callback) : createContent('main', templates, header, data, options, callback);
+
+    callback(null,content);
+}
+
+function createSplitContent(templates, header, data, options, callback) {
+    let resources = createContent('core-resources', templates, header, data, options, callback, options.omitHeader);
+    let reference = createContent('reference', templates, header, data, options, callback, true);
+    return [resources, reference];
+}
+
+function createContent(template, templates, header, data, options, callback, omitHeader) {
     let content = '';
-    if (!options.omitHeader) content += '---\n'+yaml.stringify(header)+'\n---\n\n';
-    data = options.templateCallback('main', 'pre', data);
+    if (!omitHeader) content += '---\n'+yaml.stringify(header)+'\n---\n\n';
+    data = options.templateCallback(template, 'pre', data);
     if (data.append) { content += data.append; delete data.append; }
     try {
-        content += templates.main(data);
+        let fn = templates[template];
+        content += fn(data);
     }
     catch (ex) {
         return callback(ex);
     }
-    data = options.templateCallback('main', 'post', data);
+    data = options.templateCallback(template, 'post', data);
     if (data.append) { content += data.append; delete data.append; }
     content = common.removeDupeBlankLines(content);
 
     if (options.html) content = common.html(content,header,options);
 
-    callback(null,content);
+    return content;
 }
 
 function convert(api, options, callback) {

--- a/templates/openapi3/code_python.dot
+++ b/templates/openapi3/code_python.dot
@@ -6,8 +6,14 @@ import requests
 
 {{?data.bodyParameter.present}}data = {{=data.bodyParameter.exampleValues.json}}{{?}}
 
-r = requests.{{=data.method.verb}}('{{=data.url}}', auth=('api_example_company', 'Ke+2jinhe5jM87P95aAVOz7L3ZWrtSiERtyOkkh5tEQ='){{? data.requiredParameters.length}}, params={
-{{~ data.requiredParameters :p:index}}  '{{=p.name}}': {{=p.exampleValues.json}}{{? data.requiredParameters.length-1 != index }},{{?}}{{~}}
-}{{?}}{{?data.bodyParameter.present}}, json = data{{?}}{{?data.allHeaders.length}}, headers = headers{{?}})
+r = requests.{{=data.method.verb}}(
+  '{{=data.url}}',
+  auth=('api_example_company', 'Ke+2jinhe5jM87P95aAVOz7L3ZWrtSiERtyOkkh5tEQ='){{? data.requiredParameters.length}},
+  params={
+    {{~ data.requiredParameters :p:index}}  '{{=p.name}}': {{=p.exampleValues.json}}{{? data.requiredParameters.length-1 != index }},{{?}}{{~}}
+  }{{?}}{{?data.bodyParameter.present}},
+  json = data{{?}}{{?data.allHeaders.length}},
+  headers = headers{{?}}
+)
 
 print(r.json())

--- a/templates/openapi3/core-resources.dot
+++ b/templates/openapi3/core-resources.dot
@@ -1,0 +1,18 @@
+{{ for (var r in data.resources) { }}
+{{ data.resource = data.resources[r]; }}
+
+{{= data.tags.section }}
+<h1>{{= r}}</h1>
+
+{{? data.resource.description }}{{= data.resource.description}}{{?}}
+
+{{ for (var m in data.resource.methods) { }}
+{{ data.operationUniqueName = m; }}
+{{ data.method = data.resource.methods[m]; }}
+{{ data.operationUniqueSlug = data.method.slug; }}
+{{ data.operation = data.method.operation; }}
+{{= data.templates.operation(data) }}
+{{ } /* of methods */ }}
+
+{{= data.tags.endSection }}
+{{ } /* of resources */ }}

--- a/templates/openapi3/core-resources.dot
+++ b/templates/openapi3/core-resources.dot
@@ -1,8 +1,10 @@
+# Core Resources
+
 {{ for (var r in data.resources) { }}
 {{ data.resource = data.resources[r]; }}
 
 {{= data.tags.section }}
-<h1>{{= r}}</h1>
+## {{= r}}
 
 {{? data.resource.description }}{{= data.resource.description}}{{?}}
 

--- a/templates/openapi3/operation.dot
+++ b/templates/openapi3/operation.dot
@@ -33,10 +33,4 @@
 
 {{#def.callbacks}}
 
-{{ data.security = data.operation.security ? data.operation.security : data.api.security; }}
-{{? data.security && data.security.length }}
-{{#def.authentication}}
-{{??}}
-{{#def.authentication_none}}
-{{?}}
 {{= data.tags.endSection }}

--- a/templates/openapi3/parameters.def
+++ b/templates/openapi3/parameters.def
@@ -1,5 +1,5 @@
 {{= data.tags.section }}
-<h3 id="{{=data.operationUniqueSlug}}-parameters">Parameters</h3>
+**Parameters**
 
 |Name|In|Type|Required|Description|
 |---|---|---|---|---|
@@ -7,7 +7,7 @@
 {{~}}
 
 {{? data.longDescs }}
-#### Detailed descriptions
+**Detailed descriptions**
 {{~ data.parameters :p}}{{? p.shortDesc !== p.description}}
 **{{=p.name}}**: {{=p.description}}{{?}}
 {{~}}
@@ -30,7 +30,7 @@
 {{~}}
 
 {{? data.enums && data.enums.length }}
-#### Enumerated Values
+**Enumerated Values**
 
 |Parameter|Value|
 |---|---|

--- a/templates/openapi3/reference.dot
+++ b/templates/openapi3/reference.dot
@@ -1,0 +1,79 @@
+{{? data.api.components && data.api.components.schemas }}
+{{= data.tags.section }}
+
+# Schemas
+
+{{ for (var s in data.components.schemas) { }}
+{{ var origSchema = data.components.schemas[s]; }}
+{{ var schema = data.api.components.schemas[s]; }}
+
+{{= data.tags.section }}
+<h2>{{=s}}</h2>
+<!-- backwards compatibility -->
+<a id="schema{{=s.toLowerCase()}}"></a>
+
+{{? data.options.yaml }}
+```yaml
+{{=data.utils.yaml.stringify(data.utils.getSample(schema,data.options,{quiet:true},data.api))}}
+{{??}}
+```json
+{{=data.utils.safejson(data.utils.getSample(schema,data.options,{quiet:true},data.api),null,2)}}
+{{?}}
+```
+
+{{ var enums = []; }}
+{{ var blocks = data.utils.schemaToArray(origSchema,-1,{trim:true,join:true},data); }}
+{{ for (var block of blocks) {
+     for (var p of block.rows) {
+       if (p.schema && p.schema.enum) {
+         for (var e of p.schema.enum) {
+           enums.push({name:p.name,value:e});
+         }
+       }
+     }
+   }
+}}
+
+{{~ blocks :block}}
+{{? block.title }}{{= block.title}}{{= '\n\n'}}{{?}}
+
+{{? block===blocks[0] }}
+{{= data.tags.section }}
+
+### Attributes
+{{?}}
+
+{{? block.rows.length}}|Name|Type|Required|Description|
+|---|---|---|---|---|{{?}}
+{{~ block.rows :p}}|{{=p.displayName}}|{{=p.safeType}}|{{=p.required}}|{{=p.description||'none'}}|
+{{~}}
+{{~}}
+{{? (blocks[0].rows.length === 0) && (blocks.length === 1) }}
+*None*
+{{?}}
+
+{{? enums.length > 0 }}
+{{= data.tags.section }}
+
+#### Enumerated Values
+
+|Property|Value|
+|---|---|
+{{~ enums :e}}|{{=e.name}}|{{=data.utils.toPrimitive(e.value)}}|
+{{~}}
+
+{{= data.tags.endSection }}
+{{?}}
+
+{{= data.tags.endSection }}
+{{= data.tags.endSection }}
+
+{{ } /* of schemas */ }}
+
+{{?}}
+
+{{#def.footer}}
+
+{{? data.options.discovery}}
+{{#def.discovery}}
+{{?}}

--- a/templates/openapi3/reference.dot
+++ b/templates/openapi3/reference.dot
@@ -1,14 +1,14 @@
 {{? data.api.components && data.api.components.schemas }}
 {{= data.tags.section }}
 
-# Schemas
+# Reference
 
 {{ for (var s in data.components.schemas) { }}
 {{ var origSchema = data.components.schemas[s]; }}
 {{ var schema = data.api.components.schemas[s]; }}
 
 {{= data.tags.section }}
-<h2>{{=s}}</h2>
+## {{=s}}
 <!-- backwards compatibility -->
 <a id="schema{{=s.toLowerCase()}}"></a>
 
@@ -40,7 +40,7 @@
 {{? block===blocks[0] }}
 {{= data.tags.section }}
 
-### Attributes
+**Attributes**
 {{?}}
 
 {{? block.rows.length}}|Name|Type|Required|Description|
@@ -55,7 +55,7 @@
 {{? enums.length > 0 }}
 {{= data.tags.section }}
 
-#### Enumerated Values
+**Enumerated Values**
 
 |Property|Value|
 |---|---|

--- a/widdershins.js
+++ b/widdershins.js
@@ -119,10 +119,7 @@ function doit(s) {
             console.warn(err);
         }
         else {
-            if(options.splitOutPath) {
-
-            }
-            var outfile = argv.outfile||argv._[1];
+            let outfile = argv.outfile||argv._[1];
             if (outfile) {
                 fs.writeFileSync(path.resolve(outfile),output,'utf8');
             }

--- a/widdershins.js
+++ b/widdershins.js
@@ -93,6 +93,9 @@ var argv = require('yargs')
     .boolean('yaml')
     .alias('y','yaml')
     .describe('yaml','Display JSON schemas in YAML format.')
+    .string('splitOutPath')
+    .alias('split','splitOutPath')
+    .describe('splitOutPath','Will split the output in two parts and creates two files in core-resources/index.html.md and reference/index.html.md in the provided path')
     .help('h')
     .alias('h','Show help.')
     .version()
@@ -116,9 +119,16 @@ function doit(s) {
             console.warn(err);
         }
         else {
+            if(options.splitOutPath) {
+
+            }
             var outfile = argv.outfile||argv._[1];
             if (outfile) {
                 fs.writeFileSync(path.resolve(outfile),output,'utf8');
+            }
+            else if(options.splitOutPath) {
+                fs.writeFileSync(path.resolve(options.splitOutPath + '/core-resources/index.html.md'),output[0],'utf8');
+                fs.writeFileSync(path.resolve(options.splitOutPath + '/reference/index.html.md'),output[1],'utf8');
             }
             else {
                 console.log(output);
@@ -166,6 +176,7 @@ options.customApiKeyValue = argv.customApiKeyValue;
 options.html = argv.html;
 options.respec = argv.respec;
 options.useBodyName = argv.useBodyName;
+options.splitOutPath = argv.splitOutPath;
 if (argv.search === false) options.search = false;
 if (argv.includes) options.includes = argv.includes.split(',');
 if (argv.respec) {


### PR DESCRIPTION
Closes https://gitlab.inverselink.com/hackerone/issues/issues/37387
Closes https://gitlab.inverselink.com/hackerone/issues/issues/37384

Splitting the generated md file for slate in two separate files (1 for the resources and one for the references)

The options to run the widdershins command have been expanded, the desired options for us to use are:
`--omitBody --resolve --summary --language_tabs 'shell:Shell' 'python:Python' 'ruby:Ruby' 'java:Java' 'javascript:Javascript' --split ../path/to/api-docs/source-folder ../path/to/hackerone/api/swagger.json`