### PR TITLE
Update reference.dot to show description for references

### DIFF
--- a/templates/openapi3/reference.dot
+++ b/templates/openapi3/reference.dot
@@ -9,8 +9,6 @@
 
 {{= data.tags.section }}
 ## {{=s}}
-<!-- backwards compatibility -->
-<a id="schema{{=s.toLowerCase()}}"></a>
 
 {{? data.options.yaml }}
 ```yaml
@@ -35,7 +33,8 @@
 }}
 
 {{~ blocks :block}}
-{{? block.title }}{{= block.title}}{{= '\n\n'}}{{?}}
+{{? block.title != s}}{{= block.title}}{{= '\n\n'}}{{?}}
+{{? block.title == s && schema.description}}{{= schema.description }}{{?}}
 
 {{? block===blocks[0] }}
 {{= data.tags.section }}


### PR DESCRIPTION
Closes https://gitlab.inverselink.com/hackerone/issues/issues/37705

### Summary
Update the reference.dot to show the correct description for references.

### Test Plan
Run widdershins with our swagger.json and validate that the old titles are gone and descriptions are there.