### PR TITLE
Re-add response examples in operation.dot template

### DIFF
--- a/templates/openapi3/operation.dot
+++ b/templates/openapi3/operation.dot
@@ -21,6 +21,8 @@
 {{= data.utils.getCodeSamples(data) }}
 {{?}}
 
+{{= data.utils.getResponseExamples(data) }}
+
 `{{= data.methodUpper}} {{=data.method.path}}`
 
 {{? data.operation.summary && !data.options.tocSummary}}*{{= data.operation.summary }}*{{?}}


### PR DESCRIPTION
## Description

Will re-add the example responses to the api-docs

![image](https://user-images.githubusercontent.com/1484504/72264364-ece98d00-361a-11ea-98fa-8c63ae45479f.png)
