### PR TITLE
Appends the api target to the reference link

### DIFF
--- a/lib/openapi3.js
+++ b/lib/openapi3.js
@@ -168,6 +168,8 @@ function getParameters(data) {
         data.allHeaders.push(accept);
     }
 
+    const apiTarget = data.url.split('/')[4] === "hackers" ? "hacker" : "customer";
+
     if (!Array.isArray(data.parameters)) data.parameters = [];
     data.longDescs = false;
     for (let param of data.parameters) {
@@ -193,9 +195,9 @@ function getParameters(data) {
             }
             if (pSchema["x-widdershins-oldRef"]) {
                 let schemaName = pSchema["x-widdershins-oldRef"].replace('#/components/schemas/','');
-                param.safeType = '['+schemaName+'](/reference#'+schemaName.toLowerCase()+')';
+                param.safeType = '['+schemaName+'](/'+apiTarget+'-reference#'+schemaName.toLowerCase()+')';
             }
-            if (param.refName) param.safeType = '['+param.refName+'](/reference#'+param.refName.toLowerCase()+')';
+            if (param.refName) param.safeType = '['+param.refName+'](/'+apiTarget+'-reference#'+param.refName.toLowerCase()+')';
         }
         if (pSchema) {
             param.exampleValues.object = param.example || param.default || common.getSample(pSchema,data.options,{skipReadOnly:true,quiet:true},data.api);


### PR DESCRIPTION
Instead of /reference the paths are now either /customer-reference or /hacker-reference, where the appended string is the apiTarget. The target is retrieved from the URL which is a required field on the data object that is retrieved from the swagger.json api definition.